### PR TITLE
gr_digital_rf/digital_rf_sink: Fix possible IndexError with stop_on_*

### DIFF
--- a/news/drfsink_stop_indexerror_fix.rst
+++ b/news/drfsink_stop_indexerror_fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix an IndexError when using `stop_on_skipped` or `stop_on_time_tag` with `gr_digital_rf.digital_rf_channel_sink`. If the skip/tag happened with only one data block to be written, the IndexError would trigger upon trying to index to a second data block.
+
+**Security:**
+
+* <news item>

--- a/python/gr_digital_rf/digital_rf_sink.py
+++ b/python/gr_digital_rf/digital_rf_sink.py
@@ -583,14 +583,11 @@ class digital_rf_channel_sink(gr.sync_block):
                 or self._next_rel_sample == 0
             ):
                 # write continuous data from this chunk first
-                _py_rf_write_hdf5.rf_block_write(
+                last_rel_sample = _py_rf_write_hdf5.rf_block_write(
                     self._Writer._channelObj,
                     in_data,
                     data_rel_samples[:1],
                     data_blk_idxs[:1],
-                )
-                last_rel_sample = data_rel_samples[0] + (
-                    data_blk_idxs[1] - data_blk_idxs[0]
                 )
                 last_sample = last_rel_sample + self._start_sample
                 idx = np.searchsorted(md_samples, last_sample, "right")


### PR DESCRIPTION
When using the `stop_on_skipped` or `stop_on_time_tag` flags with
`gr_digital_rf.digital_rf_channel_sink`, an IndexError could occur by
trying to reference a second data block when there is only one data
block to be written before exiting after stopping is flagged. It was
possible to rewrite the offending code to not rely on indexing into the
list of data blocks.