### PR TITLE
c, python: Use integer math to calculate file sample bounds.

### DIFF
--- a/c/include/digital_rf.h
+++ b/c/include/digital_rf.h
@@ -128,6 +128,10 @@ EXPORT int digital_rf_write_blocks_hdf5(
 		uint64_t, long double, int*, int*, int*, int*, int*, int*, uint64_t*);
 	extern "C" EXPORT int digital_rf_get_unix_time_rational(
 		uint64_t, uint64_t, uint64_t, int*, int*, int*, int*, int*, int*, uint64_t*);
+	extern "C" EXPORT int digital_rf_get_timestamp_floor(
+		uint64_t, uint64_t, uint64_t, uint64_t*, uint64_t*);
+	extern "C" EXPORT int digital_rf_get_sample_ceil(
+		uint64_t, uint64_t, uint64_t, uint64_t, uint64_t*);
 	extern "C" EXPORT Digital_rf_write_object * digital_rf_create_write_hdf5(
 		char*, hid_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, char *, int, int, int, int, int, int);
 	extern "C" EXPORT int digital_rf_write_hdf5(Digital_rf_write_object*, uint64_t, void*,uint64_t);
@@ -145,6 +149,10 @@ EXPORT int digital_rf_write_blocks_hdf5(
 		uint64_t sample_rate_numerator, uint64_t sample_rate_denominator,
 		int * year, int * month, int *day, int * hour, int * minute,
 		int * second, uint64_t * picosecond);
+	EXPORT int digital_rf_get_timestamp_floor(
+		uint64_t sample_index, uint64_t sample_rate_numerator, uint64_t sample_rate_denominator, uint64_t * second, uint64_t * picosecond);
+	EXPORT int digital_rf_get_sample_ceil(
+		uint64_t second, uint64_t picosecond, uint64_t sample_rate_numerator, uint64_t sample_rate_denominator, uint64_t * sample_index);
 	EXPORT Digital_rf_write_object * digital_rf_create_write_hdf5(
 		char * directory, hid_t dtype_id, uint64_t subdir_cadence_secs,
 		uint64_t file_cadence_millisecs, uint64_t global_start_sample,
@@ -162,6 +170,8 @@ EXPORT int digital_rf_write_blocks_hdf5(
 #endif
 
 /* Private method declarations */
+int digital_rf_get_time_parts(time_t unix_second, int * year, int * month, int *day,
+		                     int * hour, int * minute, int * second);
 int digital_rf_get_subdir_file(Digital_rf_write_object *hdf5_data_object, uint64_t global_sample,
 							   char * subdir, char * basename, uint64_t * samples_left, uint64_t * max_samples_this_file);
 int digital_rf_free_hdf5_data_object(Digital_rf_write_object *hdf5_data_object);

--- a/c/include/digital_rf_version.h
+++ b/c/include/digital_rf_version.h
@@ -1,2 +1,2 @@
 // library version, increment to match package version when C interface changes
-#define DIGITAL_RF_VERSION "2.6.0"
+#define DIGITAL_RF_VERSION "2.7.0"

--- a/python/digital_rf/digital_rf_hdf5.py
+++ b/python/digital_rf/digital_rf_hdf5.py
@@ -964,11 +964,13 @@ class DigitalRFReader(object):
         # first get the names of all possible files with data
         subdir_cadence_secs = file_properties["subdir_cadence_secs"]
         file_cadence_millisecs = file_properties["file_cadence_millisecs"]
-        samples_per_second = file_properties["samples_per_second"]
+        sample_rate_numerator = file_properties["sample_rate_numerator"]
+        sample_rate_denominator = file_properties["sample_rate_denominator"]
         filepaths = self._get_file_list(
             start_sample,
             end_sample,
-            samples_per_second,
+            sample_rate_numerator,
+            sample_rate_denominator,
             subdir_cadence_secs,
             file_cadence_millisecs,
         )
@@ -1097,12 +1099,14 @@ class DigitalRFReader(object):
 
         subdir_cadence_secs = global_properties["subdir_cadence_secs"]
         file_cadence_millisecs = global_properties["file_cadence_millisecs"]
-        samples_per_second = global_properties["samples_per_second"]
+        sample_rate_numerator = global_properties["sample_rate_numerator"]
+        sample_rate_denominator = global_properties["sample_rate_denominator"]
 
         file_list = self._get_file_list(
             sample,
             sample,
-            samples_per_second,
+            sample_rate_numerator,
+            sample_rate_denominator,
             subdir_cadence_secs,
             file_cadence_millisecs,
         )
@@ -1296,11 +1300,13 @@ class DigitalRFReader(object):
         file_properties = self.get_properties(channel_name)
         subdir_cadence_secs = file_properties["subdir_cadence_secs"]
         file_cadence_millisecs = file_properties["file_cadence_millisecs"]
-        samples_per_second = file_properties["samples_per_second"]
+        sample_rate_numerator = file_properties["sample_rate_numerator"]
+        sample_rate_denominator = file_properties["sample_rate_denominator"]
         filepaths = self._get_file_list(
             start_sample,
             end_sample,
-            samples_per_second,
+            sample_rate_numerator,
+            sample_rate_denominator,
             subdir_cadence_secs,
             file_cadence_millisecs,
         )
@@ -1340,11 +1346,13 @@ class DigitalRFReader(object):
         file_properties = self.get_properties(channel_name)
         subdir_cadence_seconds = file_properties["subdir_cadence_secs"]
         file_cadence_millisecs = file_properties["file_cadence_millisecs"]
-        samples_per_second = file_properties["samples_per_second"]
+        sample_rate_numerator = file_properties["sample_rate_numerator"]
+        sample_rate_denominator = file_properties["sample_rate_denominator"]
         file_list = self._get_file_list(
             last_sample - 1,
             last_sample,
-            samples_per_second,
+            sample_rate_numerator,
+            sample_rate_denominator,
             subdir_cadence_seconds,
             file_cadence_millisecs,
         )
@@ -1541,7 +1549,8 @@ class DigitalRFReader(object):
     def _get_file_list(
         sample0,
         sample1,
-        samples_per_second,
+        sample_rate_numerator,
+        sample_rate_denominator,
         subdir_cadence_seconds,
         file_cadence_millisecs,
     ):
@@ -1561,8 +1570,11 @@ class DigitalRFReader(object):
             Sample index for end of read (inclusive), given in the number of
             samples since the epoch (time_since_epoch*sample_rate).
 
-        samples_per_second : np.longdouble
-            Sample rate.
+        sample_rate_numerator : int
+            Numerator of sample rate in Hz.
+
+        sample_rate_denominator : int
+            Denominator of sample rate in Hz.
 
         subdir_cadence_secs : int
             Number of seconds of data found in one subdir. For example, 3600
@@ -1583,13 +1595,14 @@ class DigitalRFReader(object):
         if (sample1 - sample0) > 1e12:
             warnstr = "Requested read size, %i samples, is very large"
             warnings.warn(warnstr % (sample1 - sample0), RuntimeWarning)
-        sample0 = int(sample0)
-        sample1 = int(sample1)
-        # need to go through numpy uint64 to prevent conversion to float
-        start_ts = int(np.uint64(sample0 / samples_per_second))
-        end_ts = int(np.uint64(sample1 / samples_per_second)) + 1
-        start_msts = int(np.uint64(sample0 / samples_per_second * 1000))
-        end_msts = int(np.uint64(sample1 / samples_per_second * 1000))
+        start_ts, picoseconds = _py_rf_write_hdf5.get_timestamp_floor(
+            sample0, sample_rate_numerator, sample_rate_denominator
+        )
+        start_msts = start_ts * 1000 + picoseconds // 1000000000
+        end_ts, picoseconds = _py_rf_write_hdf5.get_timestamp_floor(
+            sample1, sample_rate_numerator, sample_rate_denominator
+        )
+        end_msts = end_ts * 1000 + picoseconds // 1000000000
 
         # get subdirectory start and end ts
         start_sub_ts = int(
@@ -1767,10 +1780,11 @@ class _channel_properties(object):
         self.top_level_dir_meta_list = top_level_dir_meta_list
         self.properties = self._read_properties()
         file_cadence_millisecs = self.properties["file_cadence_millisecs"]
-        samples_per_second = self.properties["samples_per_second"]
-        self.max_samples_per_file = int(
-            np.uint64(np.ceil(file_cadence_millisecs * samples_per_second / 1000))
-        )
+        sample_rate_numerator = self.properties["sample_rate_numerator"]
+        sample_rate_denominator = self.properties["sample_rate_denominator"]
+        num = file_cadence_millisecs * sample_rate_numerator
+        den = 1000 * sample_rate_denominator
+        self.max_samples_per_file = num // den + (num % den != 0)
 
     def _read_properties(self):
         """Get a dict of the properties stored in the drf_properties.h5 file.

--- a/python/tests/test_digital_rf_hdf5.py
+++ b/python/tests/test_digital_rf_hdf5.py
@@ -29,11 +29,6 @@ def start_datetime():
     return datetime.datetime(2014, 3, 9, 12, 30, 30, 0, None)
 
 
-@pytest.fixture(scope="session")
-def start_global_index(samples_per_second, start_datetime):
-    return digital_rf.util.time_to_sample(start_datetime, samples_per_second)
-
-
 ###############################################################################
 #  parametrized fixtures  #####################################################
 ###############################################################################
@@ -126,6 +121,7 @@ def hdf_filter_params(request):
 @pytest.fixture(
     scope="session",
     params=[
+        # sample rates must be set so that start_datetime is an exact sample time
         # srnum, srden, sdcsec, fcms
         (200, 3, 10, 1000)
     ],
@@ -225,6 +221,11 @@ def file_cadence_millisecs(sample_params):
 @pytest.fixture(scope="session")
 def samples_per_second(sample_rate_numerator, sample_rate_denominator):
     return np.longdouble(sample_rate_numerator) / sample_rate_denominator
+
+
+@pytest.fixture(scope="session")
+def start_global_index(samples_per_second, start_datetime):
+    return digital_rf.util.time_to_sample(start_datetime, samples_per_second)
 
 
 @pytest.fixture(scope="session")
@@ -447,13 +448,26 @@ def drf_reader(chdir):
 def test_get_unix_time(
     sample_rate_numerator, sample_rate_denominator, start_datetime, start_global_index
 ):
-    global_index = start_global_index + 1
-    index_dt = start_datetime + datetime.timedelta(microseconds=15000)
+    # test conversion of the start time
     dt, picoseconds = digital_rf.get_unix_time(
-        global_index, sample_rate_numerator, sample_rate_denominator
+        start_global_index, sample_rate_numerator, sample_rate_denominator
     )
-    assert dt == index_dt
-    assert picoseconds == index_dt.microsecond * 1000000
+    assert dt == start_datetime
+    assert picoseconds == start_datetime.microsecond * 1000000
+
+
+def test_sample_timestamp_conversion(
+    sample_rate_numerator, sample_rate_denominator, start_datetime, start_global_index
+):
+    # test that sample index round trips through get_sample_ceil(get_timestamp_floor())
+    for global_index in range(start_global_index, start_global_index + 100):
+        second, picosecond = digital_rf._py_rf_write_hdf5.get_timestamp_floor(
+            global_index, sample_rate_numerator, sample_rate_denominator
+        )
+        rt_global_index = digital_rf._py_rf_write_hdf5.get_sample_ceil(
+            second, picosecond, sample_rate_numerator, sample_rate_denominator
+        )
+        assert rt_global_index == global_index
 
 
 class TestDigitalRFChannel(object):


### PR DESCRIPTION
This does away with use of `long double`s for calculations with the sample rate. In the C library, this was used in `digital_rf_get_subdir_file` to determine file names and sample bounds. The `np.longdouble` sample rate was similarly used in the Python library to get the list of files containing a given sample index range.

The reason for this change is that not all platforms support `long double`s that with at least a 64-bit mantissa. This caused at least one bug on the aarch64 platform which resulted in incorrect file bounds from `digital_rf_get_subdir_file`. By using integer math that is implemented uniformly on all platforms, any bugs in the calculation should be more noticeable.

This commit also adds two new functions to the C API: `digital_rf_get_timestamp_floor` and `digital_rf_get_sample_ceil`. These
are now used to do the file sample bound calculations, and they are exposed so that users of the library can perform these calculations in a way that is consistent with what is done internally. These functions have also been exposed in the Python binding, and a test that verifies that the sample index round-trips through them is included in the Python testing suite.

Because of the added C functions, the library version has been bumped to 2.7, which means the next release of Digital RF will be 2.7.0.