### PR TITLE
Use integer math to calculate file bounds in C library

### DIFF
--- a/.github/workflows/conda-matrix.yml
+++ b/.github/workflows/conda-matrix.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up conda environment
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: dev-env
           environment-file: recipes/conda/dev-env.yml

--- a/c/include/digital_rf.h
+++ b/c/include/digital_rf.h
@@ -162,6 +162,12 @@ EXPORT int digital_rf_write_blocks_hdf5(
 #endif
 
 /* Private method declarations */
+int digital_rf_get_timestamp_floor(uint64_t sample_index, uint64_t sample_rate_numerator,
+								   uint64_t sample_rate_denominator, uint64_t * second, uint64_t * picosecond);
+int digital_rf_get_sample_ceil(uint64_t second, uint64_t picosecond,
+							   uint64_t sample_rate_numerator, uint64_t sample_rate_denominator, uint64_t * sample_index);
+int digital_rf_get_time_parts(time_t unix_second, int * year, int * month, int *day,
+		                     int * hour, int * minute, int * second);
 int digital_rf_get_subdir_file(Digital_rf_write_object *hdf5_data_object, uint64_t global_sample,
 							   char * subdir, char * basename, uint64_t * samples_left, uint64_t * max_samples_this_file);
 int digital_rf_free_hdf5_data_object(Digital_rf_write_object *hdf5_data_object);

--- a/news/integer_math_only.rst
+++ b/news/integer_math_only.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* The `digital_rf_get_unix_time` function is now deprecated, as it relies on a `long double` sample rate. Use `digital_rf_get_unix_time_rational` instead.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix incorrect file bound calculation in `digital_rf_get_subdir_file` on platforms that have a `long double` that is different from amd64, notably at least the aarch64 ARM platform. This fixes a bug where writes failed with error messages "Failed to write data" and "Request index M before first expected index N".
+
+**Security:**
+
+* <news item>

--- a/python/tests/test_digital_rf_hdf5.py
+++ b/python/tests/test_digital_rf_hdf5.py
@@ -127,9 +127,9 @@ def hdf_filter_params(request):
     scope="session",
     params=[
         # srnum, srden, sdcsec, fcms
-        (200, 3, 10, 1000)
+        (200, 3, 2, 400)
     ],
-    ids=["200/3hz,10s,1000ms"],
+    ids=["200/3hz,2s,400ms"],
 )
 def sample_params(request):
     return dict(
@@ -361,21 +361,14 @@ def data_file_list(sample_params):
     # get params as a tuple of values sorted in key order
     params = tuple(v for k, v in sorted(sample_params.items()))
     file_lists = {
-        (1000, 3, 200, 10): [
+        (400, 3, 200, 2): [
             os.path.join("2014-03-09T12-30-30", "rf@1394368230.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368231.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368232.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368233.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368234.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368236.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368237.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368238.000.h5"),
-            os.path.join("2014-03-09T12-30-30", "rf@1394368239.000.h5"),
-            os.path.join("2014-03-09T12-30-40", "rf@1394368240.000.h5"),
-            os.path.join("2014-03-09T12-30-40", "rf@1394368241.000.h5"),
-            os.path.join("2014-03-09T12-30-40", "rf@1394368242.000.h5"),
-            os.path.join("2014-03-09T12-30-40", "rf@1394368243.000.h5"),
-            os.path.join("2014-03-09T12-30-40", "rf@1394368244.000.h5"),
+            os.path.join("2014-03-09T12-30-30", "rf@1394368230.400.h5"),
+            os.path.join("2014-03-09T12-30-30", "rf@1394368230.800.h5"),
+            os.path.join("2014-03-09T12-30-30", "rf@1394368231.200.h5"),
+            os.path.join("2014-03-09T12-30-30", "rf@1394368231.600.h5"),
+            os.path.join("2014-03-09T12-30-32", "rf@1394368232.400.h5"),
+            os.path.join("2014-03-09T12-30-32", "rf@1394368232.800.h5"),
         ]
     }
     return file_lists[params]
@@ -685,7 +678,7 @@ class TestDigitalRFChannel(object):
                 global_sample_arr=global_sample_arr,
                 block_sample_arr=block_sample_arr,
             )
-            assert next_rel_index == (block_stops[-1] - bounds[0])
+            assert next_rel_index == (block_stops[-1] - start_global_index)
 
             # fail with non-matching length of sample lists
             with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #13.

If digital_rf is compiled to use 64-bit long double values (as opposed to 80-bit or more), or other compiler flags throw off the long double sample rate math, users are likely to see write failures depending on the sample rate. Usually this results in an error message of "Failed to write data" and "Request index M before first expected index N".

The current Python tests don't trigger this condition, so they pass when using 64-bit long doubles. This PR tweaks the file cadence so that the write error is triggered in these cases, so we can be forewarned that errors are likely when writing under those compilation conditions.

Then, this PR fixes the newly-broken test by doing away with use of `long double`s for calculations with the sample rate in the C library in `digital_rf_get_subdir_file` to determine file names and sample bounds. The reason for this change is that not all platforms support `long double`s that with at least a 64-bit mantissa. This caused at least one bug on the aarch64 platform which resulted in incorrect file bounds from `digital_rf_get_subdir_file`. By using integer math that is implemented uniformly on all platforms, any bugs in the calculation should be more noticable.

This PR also adds two new functions that are only used internally for now: `digital_rf_get_timestamp_floor` and `digital_rf_get_sample_ceil`. These are now used to do the file sample bound calculations. A future commit will expose these externally so that other C users and the Python library can make use of them, but that will require bumping the library version.