### PR TITLE
gr_digital_rf: Remove check for GNU Radio version.

### DIFF
--- a/news/gr_version_check_fix.rst
+++ b/news/gr_version_check_fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed #25 (digital_rf_sink: version check on GNU Radio causes TypeError) by removing the GNU Radio version check since it wasn't actually doing anything helpful anymore.
+
+**Security:**
+
+* <news item>

--- a/python/gr_digital_rf/digital_rf_sink.py
+++ b/python/gr_digital_rf/digital_rf_sink.py
@@ -14,7 +14,6 @@ import sys
 import traceback
 import warnings
 from collections import defaultdict
-from distutils.version import LooseVersion
 from itertools import chain, tee
 
 import numpy as np
@@ -371,16 +370,12 @@ class digital_rf_channel_sink(gr.sync_block):
             sys.stdout.flush()
 
         # stream tags to read (in addition to rx_time, handled specially)
-        if LooseVersion(gr.version()) >= LooseVersion("3.7.12"):
-            self._stream_tag_translators = {
-                # disable rx_freq until we figure out what to do with polyphase
-                # pmt.intern('rx_freq'): translate_rx_freq,
-                pmt.intern("metadata"): translate_metadata
-            }
-        else:
-            # USRP source in gnuradio < 3.7.12 has bad rx_freq tags, so avoid
-            # trouble by ignoring rx_freq tags for those gnuradio versions
-            self._stream_tag_translators = {pmt.intern("metadata"): translate_metadata}
+        self._stream_tag_translators = {
+            # disable rx_freq until we figure out what to do with polyphase
+            # also, USRP source in gr < 3.7.12 has bad rx_freq tags
+            # pmt.intern('rx_freq'): translate_rx_freq,
+            pmt.intern("metadata"): translate_metadata
+        }
 
         # create metadata dictionary that will be updated and written whenever
         # new metadata is received in stream tags


### PR DESCRIPTION
This check fails when GNU Radio is built from a non-version-tagged git
commit. In that case, `gr.version()` returns a string that is different
from the tagged case and is not parseable by
`distutils.version.LooseVersion`, so the check fails with a type error.

Since we're not currently even doing the frequency tag parsing, this
check doesn't actually change anything. Also, the old GNU Radio versions
for which this would have mattered are now old enough that they are
unlikely to be seen in the wild. Thus, the simplest fix is to remove
this check on the GNU Radio version.