### PR TITLE
python/watchdog_drf: Fix checking for dest_path in FileSystemEvent

### DIFF
--- a/news/watchdog-dest-path-fix.rst
+++ b/news/watchdog-dest-path-fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix bug in all watchdog utilities (watch/mirror/ringbuffer) with versions 4.0.0 and up of the watchdog package. Prior to this fix, file system events were triggering a spurious FileDeletedEvent that broke ringbuffer functionality.
+
+**Security:**
+
+* <news item>

--- a/python/digital_rf/watchdog_drf.py
+++ b/python/digital_rf/watchdog_drf.py
@@ -157,7 +157,7 @@ class DigitalRFEventHandler(RegexMatchingEventHandler):
                         match = m
 
         dest_match = False
-        if getattr(event, "dest_path", None) is not None:
+        if getattr(event, "dest_path", None):
             dest_path = fsdecode(event.dest_path)
             if not any(r.match(dest_path) for r in self.ignore_regexes):
                 for r in self.regexes:

--- a/python/examples/benchmark_rf_write_hdf5.py
+++ b/python/examples/benchmark_rf_write_hdf5.py
@@ -6,9 +6,7 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 # ----------------------------------------------------------------------------
-"""Benchmark I/O of Digital RF write in different configurations.
-
-"""
+"""Benchmark I/O of Digital RF write in different configurations."""
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/python/tools/drf_plot.py
+++ b/python/tools/drf_plot.py
@@ -8,14 +8,14 @@
 # The full license is in the LICENSE file, distributed with this software.
 # ----------------------------------------------------------------------------
 """
- drf_plot.py
+drf_plot.py
 
- $Id$
+$Id$
 
- Simple program to load (nominal) 16 bit IQ data and make some basic plots. Command
- line options are supported and data frames may be filtered from the output. The
- program can offset into a data file to limit the memory usage when plotting
- a subset of a data file.
+Simple program to load (nominal) 16 bit IQ data and make some basic plots. Command
+line options are supported and data frames may be filtered from the output. The
+program can offset into a data file to limit the memory usage when plotting
+a subset of a data file.
 
 """
 


### PR DESCRIPTION
Prior to watchdog 4.0.0, FileSystemEvent only had a dest_path attribute if it was a move event. Since 4.0.0, all FileSystemEvents have a dest_path attribute, defaulting to an empty string when not a move event.

Because we were checking for dest_path is None, with watchdog 4.0.0+ non-move events were triggering the check for dest_path and getting changed to a FileDeletedEvent. This fixes that check so that it works for all versions of watchdog.