### PR TITLE
python: Fix 'datetime.datetime' has no attribute 'timezone' 

### DIFF
--- a/news/timezone.rst
+++ b/news/timezone.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix 'datetime.datetime' has no attribute 'timezone', affecting the 2.6.10 release after removal of pytz.
+
+**Security:**
+
+* <news item>

--- a/python/tools/thor.py
+++ b/python/tools/thor.py
@@ -17,7 +17,7 @@ import re
 import sys
 import time
 from ast import literal_eval
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fractions import Fraction
 from itertools import chain, cycle, islice, repeat
 from subprocess import call
@@ -792,7 +792,7 @@ class Thor(object):
         st = drf.util.parse_identifier_to_time(starttime)
         if st is not None:
             # find next suitable start time by cycle repeat period
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             soon = now + timedelta(seconds=SETUP_TIME)
             diff = max(soon - st, timedelta(0)).total_seconds()
             periods_until_next = (diff - 1) // period + 1
@@ -811,11 +811,7 @@ class Thor(object):
                 print("End time: {0} ({1})".format(etstr, etts))
 
             if (
-                et
-                < (
-                    datetime.now(tz=datetime.timezone.utc)
-                    + timedelta(seconds=SETUP_TIME)
-                )
+                et < (datetime.now(tz=timezone.utc) + timedelta(seconds=SETUP_TIME))
             ) or (st is not None and et <= st):
                 raise ValueError("End time is before launch time!")
 
@@ -835,10 +831,9 @@ class Thor(object):
 
         # wait for the start time if it is not past
         while (st is not None) and (
-            (st - datetime.now(tz=datetime.timezone.utc))
-            > timedelta(seconds=SETUP_TIME)
+            (st - datetime.now(tz=timezone.utc)) > timedelta(seconds=SETUP_TIME)
         ):
-            ttl = int((st - datetime.now(tz=datetime.timezone.utc)).total_seconds())
+            ttl = int((st - datetime.now(tz=timezone.utc)).total_seconds())
             if (ttl % 10) == 0:
                 print("Standby {0} s remaining...".format(ttl))
                 sys.stdout.flush()
@@ -885,7 +880,7 @@ class Thor(object):
         if st is not None:
             lt = st
         else:
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             # launch on integer second by default for convenience (ceil + 2)
             lt = now.replace(microsecond=0) + timedelta(seconds=3)
         ltts = (lt - drf.util.epoch).total_seconds()
@@ -1131,7 +1126,7 @@ class Thor(object):
 
         # check that we get samples after launch
         while not u.nitems_written(0):
-            if (datetime.now(tz=datetime.timezone.utc)) - lt > timedelta(seconds=5):
+            if (datetime.now(tz=timezone.utc)) - lt > timedelta(seconds=5):
                 fg.stop()
                 # need to wait for the flowgraph to clean up,
                 # otherwise it won't exit
@@ -1148,14 +1143,10 @@ class Thor(object):
                 fg.wait()
             else:
                 # sleep until end time
-                while datetime.now(tz=datetime.timezone.utc) < et - timedelta(
-                    seconds=2
-                ):
+                while datetime.now(tz=timezone.utc) < et - timedelta(seconds=2):
                     time.sleep(1)
                 # (actually a little after to allow for inexact computer time)
-                while datetime.now(tz=datetime.timezone.utc) < et + timedelta(
-                    seconds=0.2
-                ):
+                while datetime.now(tz=timezone.utc) < et + timedelta(seconds=0.2):
                     time.sleep(0.1)
         except KeyboardInterrupt:
             # catch keyboard interrupt and simply exit

--- a/python/tools/thorosmo.py
+++ b/python/tools/thorosmo.py
@@ -16,7 +16,7 @@ import os
 import sys
 import time
 from ast import literal_eval
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fractions import Fraction
 from itertools import chain, cycle, islice, repeat
 from subprocess import call
@@ -548,7 +548,7 @@ class Thorosmo(object):
         st = drf.util.parse_identifier_to_time(starttime)
         if st is not None:
             # find next suitable start time by cycle repeat period
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             soon = now + timedelta(seconds=SETUP_TIME)
             diff = max(soon - st, timedelta(0)).total_seconds()
             periods_until_next = (diff - 1) // period + 1
@@ -567,11 +567,7 @@ class Thorosmo(object):
                 print("End time: {0} ({1})".format(etstr, etts))
 
             if (
-                et
-                < (
-                    datetime.now(tz=datetime.timezone.utc)
-                    + timedelta(seconds=SETUP_TIME)
-                )
+                et < (datetime.now(tz=timezone.utc) + timedelta(seconds=SETUP_TIME))
             ) or (st is not None and et <= st):
                 raise ValueError("End time is before launch time!")
 
@@ -591,10 +587,9 @@ class Thorosmo(object):
 
         # wait for the start time if it is not past
         while (st is not None) and (
-            (st - datetime.now(tz=datetime.timezone.utc))
-            > timedelta(seconds=SETUP_TIME)
+            (st - datetime.now(tz=timezone.utc)) > timedelta(seconds=SETUP_TIME)
         ):
-            ttl = int((st - datetime.now(tz=datetime.timezone.utc)).total_seconds())
+            ttl = int((st - datetime.now(tz=timezone.utc)).total_seconds())
             if (ttl % 10) == 0:
                 print("Standby {0} s remaining...".format(ttl))
                 sys.stdout.flush()
@@ -635,7 +630,7 @@ class Thorosmo(object):
         if st is not None:
             lt = st
         else:
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             # launch on integer second by default for convenience (ceil + 2)
             lt = now.replace(microsecond=0) + timedelta(seconds=3)
         ltts = (lt - drf.util.epoch).total_seconds()
@@ -858,7 +853,7 @@ class Thorosmo(object):
             graph.append(connections)
 
         # start the flowgraph once we are near the launch time
-        while (lt - datetime.now(tz=datetime.timezone.utc)) > timedelta(seconds=0.5):
+        while (lt - datetime.now(tz=timezone.utc)) > timedelta(seconds=0.5):
             time.sleep(0.1)
 
         # start the flowgraph, samples should start at launch time
@@ -871,14 +866,10 @@ class Thorosmo(object):
                 fg.wait()
             else:
                 # sleep until end time
-                while datetime.now(tz=datetime.timezone.utc) < et - timedelta(
-                    seconds=2
-                ):
+                while datetime.now(tz=timezone.utc) < et - timedelta(seconds=2):
                     time.sleep(1)
                 # (actually a little after to allow for inexact computer time)
-                while datetime.now(tz=datetime.timezone.utc) < et + timedelta(
-                    seconds=0.2
-                ):
+                while datetime.now(tz=timezone.utc) < et + timedelta(seconds=0.2):
                     time.sleep(0.1)
         except KeyboardInterrupt:
             # catch keyboard interrupt and simply exit

--- a/python/tools/thorpluto.py
+++ b/python/tools/thorpluto.py
@@ -17,7 +17,7 @@ import re
 import sys
 import time
 from ast import literal_eval
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fractions import Fraction
 from itertools import chain, cycle, islice, repeat
 from subprocess import call
@@ -515,7 +515,7 @@ class Thorpluto(object):
         st = drf.util.parse_identifier_to_time(starttime)
         if st is not None:
             # find next suitable start time by cycle repeat period
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             soon = now + timedelta(seconds=SETUP_TIME)
             diff = max(soon - st, timedelta(0)).total_seconds()
             periods_until_next = (diff - 1) // period + 1
@@ -534,11 +534,7 @@ class Thorpluto(object):
                 print("End time: {0} ({1})".format(etstr, etts))
 
             if (
-                et
-                < (
-                    datetime.now(tz=datetime.timezone.utc)
-                    + timedelta(seconds=SETUP_TIME)
-                )
+                et < (datetime.now(tz=timezone.utc) + timedelta(seconds=SETUP_TIME))
             ) or (st is not None and et <= st):
                 raise ValueError("End time is before launch time!")
 
@@ -558,10 +554,9 @@ class Thorpluto(object):
 
         # wait for the start time if it is not past
         while (st is not None) and (
-            (st - datetime.now(tz=datetime.timezone.utc))
-            > timedelta(seconds=SETUP_TIME)
+            (st - datetime.now(tz=timezone.utc)) > timedelta(seconds=SETUP_TIME)
         ):
-            ttl = int((st - datetime.now(tz=datetime.timezone.utc)).total_seconds())
+            ttl = int((st - datetime.now(tz=timezone.utc)).total_seconds())
             if (ttl % 10) == 0:
                 print("Standby {0} s remaining...".format(ttl))
                 sys.stdout.flush()
@@ -604,7 +599,7 @@ class Thorpluto(object):
         if st is not None:
             lt = st
         else:
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             # launch on integer second by default for convenience (ceil + 2)
             lt = now.replace(microsecond=0) + timedelta(seconds=3)
         ltts = (lt - drf.util.epoch).total_seconds()
@@ -822,7 +817,7 @@ class Thorpluto(object):
             graph.append(connections)
 
         # start the flowgraph once we are near the launch time
-        while (lt - datetime.now(tz=datetime.timezone.utc)) > timedelta(seconds=0.5):
+        while (lt - datetime.now(tz=timezone.utc)) > timedelta(seconds=0.5):
             time.sleep(0.1)
 
         # start the flowgraph, samples should start at launch time
@@ -835,14 +830,10 @@ class Thorpluto(object):
                 fg.wait()
             else:
                 # sleep until end time
-                while datetime.now(tz=datetime.timezone.utc) < et - timedelta(
-                    seconds=2
-                ):
+                while datetime.now(tz=timezone.utc) < et - timedelta(seconds=2):
                     time.sleep(1)
                 # (actually a little after to allow for inexact computer time)
-                while datetime.now(tz=datetime.timezone.utc) < et + timedelta(
-                    seconds=0.2
-                ):
+                while datetime.now(tz=timezone.utc) < et + timedelta(seconds=0.2):
                     time.sleep(0.1)
         except KeyboardInterrupt:
             # catch keyboard interrupt and simply exit

--- a/python/tools/uhdtodrf.py
+++ b/python/tools/uhdtodrf.py
@@ -17,7 +17,7 @@ import re
 import sys
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fractions import Fraction
 from itertools import chain, cycle, islice, repeat
 from subprocess import call
@@ -815,7 +815,7 @@ class Recorder(object):
         st = drf.util.parse_identifier_to_time(starttime)
         if st is not None:
             # find next suitable start time by cycle repeat period
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             soon = now + timedelta(seconds=SETUP_TIME)
             diff = max(soon - st, timedelta(0)).total_seconds()
             periods_until_next = (diff - 1) // period + 1
@@ -834,11 +834,7 @@ class Recorder(object):
                 print("End time: {0} ({1})".format(etstr, etts))
 
             if (
-                et
-                < (
-                    datetime.now(tz=datetime.timezone.utc)
-                    + timedelta(seconds=SETUP_TIME)
-                )
+                et < (datetime.now(tz=timezone.utc) + timedelta(seconds=SETUP_TIME))
             ) or (st is not None and et <= st):
                 raise ValueError("End time is before launch time!")
 
@@ -858,10 +854,9 @@ class Recorder(object):
 
             # wait for the start time if it is not past
         while (st is not None) and (
-            (st - datetime.now(tz=datetime.timezone.utc))
-            > timedelta(seconds=SETUP_TIME)
+            (st - datetime.now(tz=timezone.utc)) > timedelta(seconds=SETUP_TIME)
         ):
-            ttl = int((st - datetime.now(tz=datetime.timezone.utc)).total_seconds())
+            ttl = int((st - datetime.now(tz=timezone.utc)).total_seconds())
             if (ttl % 10) == 0:
                 print("Standby {0} s remaining...".format(ttl))
                 sys.stdout.flush()
@@ -894,7 +889,7 @@ class Recorder(object):
         if st is not None:
             lt = st
         else:
-            now = datetime.now(tz=datetime.timezone.utc)
+            now = datetime.now(tz=timezone.utc)
             # launch on integer second by default for convenience (ceil + 2)
             lt = now.replace(microsecond=0) + timedelta(seconds=3)
         ltts = (lt - drf.util.epoch).total_seconds()
@@ -1098,9 +1093,9 @@ class Recorder(object):
             stream.issue_stream_cmd(stream_cmd)
             while not end_rec.is_set():
                 if et is not None:
-                    stop_bool = datetime.now(
-                        tz=datetime.timezone.utc
-                    ) >= et - timedelta(seconds=1)
+                    stop_bool = datetime.now(tz=timezone.utc) >= et - timedelta(
+                        seconds=1
+                    )
                     if stop_bool:
                         end_rec.set()
 


### PR DESCRIPTION
In places where we `from datetime import datetime`, the module `datetime` is not available and therefore doesn't contain `timezone`. Fix this by importing `timezone` as well.